### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Appli_course
-Une application qui gère ingrédient, menu, et liste de course.
+Une application qui gère ingrédients, menu, et liste de course.


### PR DESCRIPTION
## Summary
- fix typo in README usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840257e67a8832cb737993c769401d3