### PR TITLE
Add localStorage persistence

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -145,6 +145,25 @@ let shoppingList = {};
 let listMenuList = [];
 let filteredRecipes = [];
 
+function saveRecipesToLocalStorage() {
+  localStorage.setItem('recipes', JSON.stringify(recipes));
+}
+
+function saveMenusToLocalStorage() {
+  localStorage.setItem('listMenuList', JSON.stringify(listMenuList));
+}
+
+function loadFromLocalStorage() {
+  const storedRecipes = localStorage.getItem('recipes');
+  if (storedRecipes) {
+    recipes = JSON.parse(storedRecipes);
+  }
+  const storedMenus = localStorage.getItem('listMenuList');
+  if (storedMenus) {
+    listMenuList = JSON.parse(storedMenus);
+  }
+}
+
 // Catégories et saisons, healthType, difficulté
 const categories = [
   'Fruits et Légumes',
@@ -170,6 +189,7 @@ let options = {
 
 // Fonction d'initialisation
 function initialize() {
+  loadFromLocalStorage();
   // Navigation
   document.querySelectorAll('.tab-link').forEach(link => {
     link.addEventListener('click', (e) => {

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -334,7 +334,9 @@ function saveMenuList (){
   
 
   updateListMenuList ();
-  updateShoppingList ();//mets à jour la liste de course 
+  updateShoppingList ();//mets à jour la liste de course
+  saveMenusToLocalStorage();
+  saveRecipesToLocalStorage();
  
   //réinitialiser l'objet globale menuList pour pouvoir recréer une liste, attention à faire en dernier pour que la liste de shopping puisse se remplir
   menuList = { name: '', date: '', recipes: [] };// Crée une nouvelle instance d'objet
@@ -416,9 +418,11 @@ function deleteMenuList (index){
   });
 
     listMenuList.splice(index, 1);
-    
+
     updateListMenuList();
     updateShoppingList();
+    saveMenusToLocalStorage();
+    saveRecipesToLocalStorage();
     document.getElementById('recipe-modal').style.display = 'none';
   }
 
@@ -465,6 +469,9 @@ function drop(event, targetDayIndex, targetSlotIndex) {
   updateMenuList();
 }
 
+
+// Affiche les listes de menus enregistrées lors du chargement
+updateListMenuList();
 
 
 

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -58,6 +58,7 @@
     event.stopPropagation();
     recipes[index].favori = !recipes[index].favori;
     updateRecipeList();
+    saveRecipesToLocalStorage();
   }
 
   /*///////////////TRIER EN FONCTION DU CRITERE///////////////*/
@@ -275,10 +276,11 @@
       // Modifier une recette existante
       recipes[index] = { ...recipes[index], name, ingredients, season, rating, instructions, health, difficulty};
       showRecipeDetails(index);
-      
+
     }
-  
+
     updateRecipeList();
+    saveRecipesToLocalStorage();
     
     //document.getElementById('recipe-modal').style.display = 'none';
   }
@@ -291,6 +293,7 @@
       // Mise à jour de `filteredRecipes`
       filteredRecipes = filteredRecipes.filter(i => i !== index).map(i => (i > index ? i - 1 : i));
       updateRecipeList();
+      saveRecipesToLocalStorage();
       document.getElementById('recipe-modal').style.display = 'none';
     }
   }


### PR DESCRIPTION
## Summary
- persist recipes and saved menus in `localStorage`
- restore saved data on initialization
- refresh menu list view on page load

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684055358ac4832c93bba9d656773623