### PR TITLE
Affichage liste course

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -405,6 +405,13 @@ function showMenuListDetails(index) {
     }).join('');
   }
 
+  const shoppingRows = Object.entries(shoppingList).map(([category, items]) => {
+    const rows = Object.entries(items).map(([name, { quantity, unit }]) =>
+      `<tr><td>${quantity} ${unit}</td><td>${name}</td></tr>`
+    ).join('');
+    return `<tr class="category-header"><td colspan="2">${category}</td></tr>${rows}`;
+  }).join('');
+
   modalBody.innerHTML = `
     <h2>${menuListLocal.name}</h2>
     <p>Date de création: ${menuListLocal.date}</p>
@@ -413,19 +420,10 @@ function showMenuListDetails(index) {
       <thead><tr><th>Date</th><th>Midi</th><th>Soir</th></tr></thead>
       <tbody>${tableRows}</tbody>
     </table>
-    <div class="shopping-list-container">
-      ${Object.entries(shoppingList).map(([category, items]) => `
-        <div class="shopping-list-category">
-          <h3>${category}</h3>
-          ${Object.entries(items).map(([name, {quantity, unit}]) => `
-            <div class="shopping-list-item">
-              <span>${name}</span>
-              <span>${quantity} ${unit}</span>
-            </div>
-          `).join('')}
-        </div>
-      `).join('')}
-    </div>
+    <table class="shopping-list-table">
+      <thead><tr><th>Quantité</th><th>Ingrédient</th></tr></thead>
+      <tbody>${shoppingRows}</tbody>
+    </table>
     <button onclick="generatePDF(${index})">Télécharger la liste de courses</button>
     <button onclick="editMenuList(${index})">Modifier</button>
     <button onclick="deleteMenuList(${index})">Supprimer</button>

--- a/styles.css
+++ b/styles.css
@@ -242,3 +242,19 @@ body {
 .menu-plan-table th {
   background-color: #f5f5f5;
 }
+
+.shopping-list-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+.shopping-list-table th,
+.shopping-list-table td {
+  border: 1px solid #ddd;
+  padding: 6px;
+}
+.shopping-list-table .category-header td {
+  background-color: #c8e6c9;
+  font-weight: bold;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- show menu list ingredients in a grouped table within the modal
- style shopping list table for improved appearance

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68414f7f507c832ca7f1d5b2f9ac2bc7