### PR TITLE
Update shopping list modal layout

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -405,12 +405,20 @@ function showMenuListDetails(index) {
     }).join('');
   }
 
-  const shoppingRows = Object.entries(shoppingList).map(([category, items]) => {
-    const rows = Object.entries(items).map(([name, { quantity, unit }]) =>
-      `<tr><td>${quantity} ${unit}</td><td>${name}</td></tr>`
-    ).join('');
-    return `<tr class="category-header"><td colspan="2">${category}</td></tr>${rows}`;
-  }).join('');
+  const shoppingCategories = Object.entries(shoppingList);
+  let shoppingRows = '';
+  for (let i = 0; i < shoppingCategories.length; i += 3) {
+    const cells = shoppingCategories.slice(i, i + 3).map(([category, items]) => {
+      const itemsHtml = Object.entries(items).map(([name, { quantity, unit }]) =>
+        `${quantity} ${unit} ${name}`
+      ).join('<br>');
+      return `<td><strong>${category}</strong><br>${itemsHtml}</td>`;
+    });
+    while (cells.length < 3) {
+      cells.push('<td></td>');
+    }
+    shoppingRows += `<tr>${cells.join('')}</tr>`;
+  }
 
   modalBody.innerHTML = `
     <h2>${menuListLocal.name}</h2>
@@ -421,7 +429,6 @@ function showMenuListDetails(index) {
       <tbody>${tableRows}</tbody>
     </table>
     <table class="shopping-list-table">
-      <thead><tr><th>Quantité</th><th>Ingrédient</th></tr></thead>
       <tbody>${shoppingRows}</tbody>
     </table>
     <button onclick="generatePDF(${index})">Télécharger la liste de courses</button>

--- a/styles.css
+++ b/styles.css
@@ -248,13 +248,13 @@ body {
   border-collapse: collapse;
   margin-top: 20px;
 }
-.shopping-list-table th,
 .shopping-list-table td {
   border: 1px solid #ddd;
   padding: 6px;
+  width: 33%;
+  vertical-align: top;
 }
-.shopping-list-table .category-header td {
-  background-color: #c8e6c9;
-  font-weight: bold;
-  text-align: center;
+.shopping-list-table td strong {
+  display: block;
+  margin-bottom: 4px;
 }


### PR DESCRIPTION
## Summary
- display 3 ingredient categories per row in shopping list modal
- drop the old ingredient/quantity headers
- adjust styles for compact view

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684155039a2c832cb78485b22852a14c