### PR TITLE
Fix ingredient and usage count sync

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -157,11 +157,23 @@ let shoppingList = {};
 let listMenuList = [];
 let filteredRecipes = [];
 
+function recomputeUsageCounts() {
+  recipes.forEach(r => r.usageCount = 0);
+  listMenuList.forEach(list => {
+    list.recipes.forEach(rcp => {
+      const found = recipes.find(r => r.name === rcp.name);
+      if (found) found.usageCount += 1;
+    });
+  });
+}
+
 function saveRecipesToLocalStorage() {
+  recomputeUsageCounts();
   localStorage.setItem('recipes', JSON.stringify(recipes));
 }
 
 function saveMenusToLocalStorage() {
+  recomputeUsageCounts();
   localStorage.setItem('listMenuList', JSON.stringify(listMenuList));
 }
 
@@ -179,6 +191,7 @@ function loadFromLocalStorage() {
   if (storedMenus) {
     listMenuList = JSON.parse(storedMenus);
   }
+  recomputeUsageCounts();
 }
 
 // Catégories et saisons, healthType, difficulté

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -481,7 +481,9 @@ function showMenuListDetails(index) {
 function formattingShoppingList(index){
   shoppingList = {};
   listMenuList[index].recipes.forEach(recipe => {
-    recipe.ingredients.forEach(ingredient => {
+    const base = recipes.find(r => r.name === recipe.name);
+    if (!base) return; // si la recette n'existe plus
+    base.ingredients.forEach(ingredient => {
       const { quantity, unit, name, category } = ingredient;
       if (!shoppingList[category]) {
         shoppingList[category] = {};
@@ -502,7 +504,9 @@ function formattingShoppingList(index){
 function updateCurrentShoppingList(){
   shoppingList = {};
   menuList.recipes.forEach(recipe => {
-    recipe.ingredients.forEach(ingredient => {
+    const base = recipes.find(r => r.name === recipe.name);
+    if (!base) return;
+    base.ingredients.forEach(ingredient => {
       const { quantity, unit, name, category } = ingredient;
       if (!shoppingList[category]) {
         shoppingList[category] = {};
@@ -580,7 +584,7 @@ function deleteMenuList (index){
   });
 
     listMenuList.splice(index, 1);
-
+    shoppingList = {};
     updateListMenuList();
     saveMenusToLocalStorage();
     saveRecipesToLocalStorage();
@@ -629,6 +633,32 @@ function drop(event, targetDayIndex, targetSlotIndex) {
   menuListArray[targetDayIndex][targetSlotIndex] = temp;
 
   updateMenuList();
+}
+
+function updateMenusWithRecipe(oldName, newRecipe) {
+  listMenuList.forEach(list => {
+    list.recipes = list.recipes.map(r =>
+      r.name === oldName ? (newRecipe ? JSON.parse(JSON.stringify(newRecipe)) : null) : r
+    ).filter(Boolean);
+    if (list.menu) {
+      list.menu = list.menu.map(day => day.map(slot => {
+        if (slot && slot.name === oldName) {
+          return newRecipe ? JSON.parse(JSON.stringify(newRecipe)) : null;
+        }
+        return slot;
+      }));
+    }
+  });
+
+  menuList.recipes = menuList.recipes.map(r =>
+    r.name === oldName ? (newRecipe ? newRecipe : null) : r
+  ).filter(Boolean);
+  menuListArray = menuListArray.map(day => day.map(slot => {
+    if (slot && slot.name === oldName) {
+      return newRecipe ? newRecipe : null;
+    }
+    return slot;
+  }));
 }
 
 

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -315,16 +315,19 @@
     if (index === null) {
       // Ajouter une nouvelle recette
       recipes.push(recipe);
-      index = recipes.length - 1;//copie l'index du dernier élément ajouté aux tableau des recettes sinon l'index = null.
+      index = recipes.length - 1;
       showRecipeDetails(index);
     } else {
+      const oldName = recipes[index].name;
       // Modifier une recette existante
       recipes[index] = { ...recipes[index], name, ingredients, ingredientNames, season, rating, instructions, health, difficulty};
+      updateMenusWithRecipe(oldName, recipes[index]);
       showRecipeDetails(index);
 
     }
 
     updateRecipeList();
+    saveMenusToLocalStorage();
     saveRecipesToLocalStorage();
     
     //document.getElementById('recipe-modal').style.display = 'none';
@@ -333,11 +336,14 @@
   /*/////////////SUPPRIME UNE RECETTE/////////// */
   function deleteRecipe(index) {
     if (confirm('Êtes-vous sûr de vouloir supprimer cette recette ?')) {
+      const oldName = recipes[index].name;
       recipes.splice(index, 1);
       filteredRecipes.splice(index, 1);
       // Mise à jour de `filteredRecipes`
       filteredRecipes = filteredRecipes.filter(i => i !== index).map(i => (i > index ? i - 1 : i));
+      updateMenusWithRecipe(oldName, null);
       updateRecipeList();
+      saveMenusToLocalStorage();
       saveRecipesToLocalStorage();
       document.getElementById('recipe-modal').style.display = 'none';
     }


### PR DESCRIPTION
## Summary
- recompute recipe usage by scanning saved menus
- refresh menus when recipes change or are removed
- update shopping list generation to use latest recipes

## Testing
- `node --check scripts/main.js`
- `node --check scripts/menu.js`
- `node --check scripts/recipes.js`


------
https://chatgpt.com/codex/tasks/task_e_6841bdbe388c832c8d8a6aac30f0de32