### PR TITLE
Fix recipe removal from menu

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -600,7 +600,7 @@ function removeFromMenu(dayIndex, slotIndex) {
   const recipeToRemove = menuListArray[dayIndex][slotIndex];
 
     // Supprimer la recette de menuList
-    const recipeIndex = menuList.recipes.indexOf(recipeToRemove);
+    const recipeIndex = menuList.recipes.findIndex(r => r.name === recipeToRemove.name);
    
     if (recipeIndex !== -1) {
       menuList.recipes.splice(recipeIndex, 1); // Supprimer la recette du menuList


### PR DESCRIPTION
## Summary
- fix `removeFromMenu` to find recipe index by name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c25999f0832c870e14f918460d82