### PR TITLE
Fix saveMenuList when form hidden

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -340,7 +340,10 @@ function updateMenuList() {
 
 
 function saveMenuList (){
-  menuList.name = document.getElementById('menu-list-name').value;
+  const nameInput = document.getElementById('menu-list-name');
+  if (nameInput) {
+    menuList.name = nameInput.value;
+  }
   const duplicate = listMenuList.some((list, idx) => list.name === menuList.name && idx !== editingMenuIndex);
   if (duplicate) {
     alert('Nom déjà utilisé');


### PR DESCRIPTION
## Summary
- handle missing `menu-list-name` element when saving

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842a6f19d38832c8ec0bd1a08e2e87a