### PR TITLE
Fix random menu behavior

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -23,6 +23,9 @@ let currentMenuDetailIndex = null; // index de la liste de menu actuellement aff
 
     document.getElementById('menu-list-name').value =  'Liste du ' + new Date().toLocaleDateString('fr-FR');
 
+    // Pré-remplir la date de début avec la date du jour
+    document.getElementById('menu-start-date').value = getTodayDate();
+
     document.getElementById('menu-start-date').addEventListener('change', handleDateChange);
     document.getElementById('menu-end-date').addEventListener('change', handleDateChange);
 
@@ -224,6 +227,9 @@ function randomMenuList() {
   updateMenuList();
   updateCurrentShoppingList();
   refreshCurrentMenuDetails();
+
+  // Fermer le modal de recherche après le remplissage aléatoire
+  document.getElementById('recipe-modal').style.display = 'none';
 }
 
 /*////////////////////AJOUTER UNE RECETTE AU MENU/////////////////////*/


### PR DESCRIPTION
## Summary
- set default start date when creating a menu list
- close the search modal after random fill

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ab03f270832cbf6fe56c8d053ff2