### PR TITLE
Fix modal closing after adding recipe

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -269,6 +269,8 @@ function addRecipeToMenu(recipeIndex) {
     updateCurrentShoppingList();
     refreshCurrentMenuDetails();
   }
+  // Fermer la fenêtre une fois la recette ajoutée
+  document.getElementById('recipe-modal').style.display = 'none';
 }
 
 /*////////////////METS A JOUR LA LISTE DE MENU EN COURS DE CREATION//////////////*/


### PR DESCRIPTION
## Summary
- close the recipe modal after adding a recipe to a menu

## Testing
- `pytest`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad52e2dc832c8fb2d49787bbe418