### PR TITLE
Refactor scripts into ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,9 +59,7 @@
     </div>
   </div>
 
-  <script src="scripts/recipes.js"></script><!--initialisation en premier pour que main.js puisse appeler updateRecipeList()-->
-  <script src="scripts/main.js"></script>
-  <script src="scripts/menu.js"></script>
+  <script type="module" src="scripts/main.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.14/jspdf.plugin.autotable.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,226 +1,12 @@
-// Initialisation des recettes et autres variables
-let recipes = [{
-    name: "Salade d'été",
-    health: "healthy",
-    difficulty: 1,
-    favori: false,
-    ingredients: [
-      { quantity: 2, unit: "pièces", name: "Tomates", category: "Fruits et Légumes" },
-      { quantity: 1, unit: "pièce", name: "Concombre", category: "Fruits et Légumes" },
-      { quantity: 50, unit: "g", name: "Feta", category: "Produits Laitiers" },
-      { quantity: 10, unit: "ml", name: "Huile d'olive", category: "Épicerie" }
-    ],
-    ingredientNames: ["Tomates", "Concombre", "Feta", "Huile d'olive"],
-    season: "été",
-    rating: 4,
-    instructions: "Couper les tomates et le concombre en dés, émietter la feta et mélanger le tout avec de l'huile d'olive.",
-    creationDate: "2024-08-01T10:00:00Z",
-    usageCount: 0
-  },
-  {
-    name: "Soupe d'hiver",
-    health: "healthy",
-    difficulty: 2,
-    favori: false,
-    ingredients: [
-      { quantity: 3, unit: "pièces", name: "Carottes", category: "Fruits et Légumes" },
-      { quantity: 2, unit: "pièces", name: "Pommes de terre", category: "Fruits et Légumes" },
-      { quantity: 1, unit: "L", name: "Bouillon de légumes", category: "Boissons" },
-      { quantity: 1, unit: "pièce", name: "Oignon", category: "Fruits et Légumes" }
-    ],
-    ingredientNames: ["Carottes", "Pommes de terre", "Bouillon de légumes", "Oignon"],
-    season: "hiver",
-    rating: 5,
-    instructions: "Faire revenir l'oignon, ajouter les carottes et pommes de terre coupées en morceaux, puis le bouillon. Laisser mijoter jusqu'à cuisson des légumes.",
-    creationDate: "2024-01-15T12:00:00Z",
-    usageCount: 0
-  },
-  {
-    name: "Gratin dauphinois",
-    health: "gras",
-    difficulty: 2,
-    favori: false,
-    ingredients: [
-      { quantity: 1, unit: "kg", name: "Pommes de terre", category: "Fruits et Légumes" },
-      { quantity: 500, unit: "ml", name: "Crème fraîche", category: "Produits Laitiers" },
-      { quantity: 100, unit: "g", name: "Gruyère râpé", category: "Produits Laitiers" },
-      { quantity: 2, unit: "gousses", name: "Ail", category: "Épicerie" }
-    ],
-    ingredientNames: ["Pommes de terre", "Crème fraîche", "Gruyère râpé", "Ail"],
-    season: "toute l'année",
-    rating: 4,
-    instructions: "Éplucher et couper les pommes de terre en rondelles, les disposer dans un plat à gratin frotté à l'ail, verser la crème et parsemer de gruyère. Cuire au four à 180°C pendant 45 minutes.",
-    creationDate: "2024-05-20T18:00:00Z",
-    usageCount: 0
-  },
-  {
-    name: "Soupe à la citrouille",
-    health: "healthy",
-    difficulty: 3,
-    favori: false,
-    ingredients: [
-      { quantity: 1, unit: "kg", name: "Citrouille", category: "Fruits et Légumes" },
-      { quantity: 1, unit: "pièce", name: "Oignon", category: "Fruits et Légumes" },
-      { quantity: 2, unit: "gousse", name: "Ail", category: "Épicerie" },
-      { quantity: 1, unit: "l", name: "Bouillon de légumes", category: "Boissons" }
-    ],
-    ingredientNames: ["Citrouille", "Oignon", "Ail", "Bouillon de légumes"],
-    season: "automne",
-    rating: 5,
-    instructions: "Faire revenir l'oignon et l'ail dans une casserole. Ajouter la citrouille coupée en morceaux et le bouillon de légumes. Cuire jusqu'à ce que la citrouille soit tendre, puis mixer jusqu'à obtenir une texture lisse.",
-    creationDate: "2024-09-10T12:00:00Z",
-    usageCount: 0
-  },
-  {
-    name: "Tarte aux pommes",
-    health: "normal",
-    difficulty: 2,
-    favori: false,
-    ingredients: [
-      { quantity: 1, unit: "pâte", name: "Pâte brisée", category: "Autres" },
-      { quantity: 4, unit: "pièces", name: "Pommes", category: "Fruits et Légumes" },
-      { quantity: 100, unit: "g", name: "Sucre", category: "Épicerie" },
-      { quantity: 50, unit: "g", name: "Beurre", category: "Produits Laitiers" }
-    ],
-    ingredientNames: ["Pâte brisée", "Pommes", "Sucre", "Beurre"],
-    season: "automne",
-    rating: 4,
-    instructions: "Étaler la pâte brisée dans un moule. Éplucher et trancher les pommes, les disposer sur la pâte. Saupoudrer de sucre et de petits morceaux de beurre. Cuire au four préchauffé à 180°C pendant environ 35 minutes.",
-    creationDate: "2024-09-20T15:00:00Z",
-    usageCount: 0
-  },
-  {
-    name: "Smoothie aux fruits rouges",
-    health: "normal",
-    difficulty: 1,
-    favori: false,
-    ingredients: [
-      { quantity: 200, unit: "g", name: "Fruits rouges mélangés", category: "Fruits et Légumes" },
-      { quantity: 1, unit: "pièce", name: "Banane", category: "Fruits et Légumes" },
-      { quantity: 200, unit: "ml", name: "Yaourt nature", category: "Produits Laitiers" },
-      { quantity: 1, unit: "cuillère à soupe", name: "Miel", category: "Épicerie" }
-    ],
-    ingredientNames: ["Fruits rouges mélangés", "Banane", "Yaourt nature", "Miel"],
-    season: "été",
-    rating: 5,
-    instructions: "Mixer les fruits rouges, la banane, le yaourt et le miel jusqu'à obtenir une consistance lisse. Servir immédiatement.",
-    creationDate: "2024-07-15T08:00:00Z",
-    usageCount: 0
-  }
-];
-let menuList = {
-  name: '',
-  date: '',
-  recipes: [],
-  startDate: null,
-  menu: []
-};
-/*////////////STRUCTURE DE MENU LIST////////////////
-menuList = {
-  name: "Liste d'été et d'hiver",
-  date: "26/08/2024",
-  startDate: "2024-08-26T00:00:00.000Z",
-  menu: [],
-  recipes: [
-    {
-      name: "Salade d'été",
-      ingredients: [
-        { quantity: 2, unit: "pièces", name: "Tomates", category: "Fruits et Légumes" },
-        { quantity: 1, unit: "pièce", name: "Concombre", category: "Fruits et Légumes" },
-        { quantity: 50, unit: "g", name: "Feta", category: "Produits Laitiers" },
-        { quantity: 10, unit: "ml", name: "Huile d'olive", category: "Épicerie" }
-      ],
-      season: "été",
-      rating: 4,
-      instructions: "Couper les tomates et le concombre en dés, émietter la feta et mélanger le tout avec de l'huile d'olive.",
-      creationDate: "2024-08-01T10:00:00Z",
-      usageCount: 0
-    },
-    {
-      name: "Soupe d'hiver",
-      ingredients: [
-        { quantity: 3, unit: "pièces", name: "Carottes", category: "Fruits et Légumes" },
-        { quantity: 2, unit: "pièces", name: "Pommes de terre", category: "Fruits et Légumes" },
-        { quantity: 1, unit: "L", name: "Bouillon de légumes", category: "Boissons" },
-        { quantity: 1, unit: "pièce", name: "Oignon", category: "Fruits et Légumes" }
-      ],
-      season: "hiver",
-      rating: 5,
-      instructions: "Faire revenir l'oignon, ajouter les carottes et pommes de terre coupées en morceaux, puis le bouillon. Laisser mijoter jusqu'à cuisson des légumes.",
-      creationDate: "2024-01-15T12:00:00Z",
-      usageCount: 0
-    }
-  ]
-};*/
+import { loadFromLocalStorage } from './storage.js';
+import { setRecipes, updateRecipeList } from './recipes.js';
+import { setListMenuList, updateListMenuList } from './menus.js';
 
-let shoppingList = {};
-let listMenuList = [];
-let filteredRecipes = [];
-
-function recomputeUsageCounts() {
-  recipes.forEach(r => r.usageCount = 0);
-  listMenuList.forEach(list => {
-    list.recipes.forEach(rcp => {
-      const found = recipes.find(r => r.name === rcp.name);
-      if (found) found.usageCount += 1;
-    });
-  });
-}
-
-function saveRecipesToLocalStorage() {
-  recomputeUsageCounts();
-  localStorage.setItem('recipes', JSON.stringify(recipes));
-}
-
-function saveMenusToLocalStorage() {
-  recomputeUsageCounts();
-  localStorage.setItem('listMenuList', JSON.stringify(listMenuList));
-}
-
-function loadFromLocalStorage() {
-  const storedRecipes = localStorage.getItem('recipes');
-  if (storedRecipes) {
-    recipes = JSON.parse(storedRecipes);
-    recipes.forEach(r => {
-      if (!r.ingredientNames) {
-        r.ingredientNames = r.ingredients.map(i => i.name);
-      }
-    });
-  }
-  const storedMenus = localStorage.getItem('listMenuList');
-  if (storedMenus) {
-    listMenuList = JSON.parse(storedMenus);
-  }
-  recomputeUsageCounts();
-}
-
-// Catégories et saisons, healthType, difficulté
-const categories = [
-  'Fruits et Légumes',
-  'Viandes et Poissons',
-  'Produits Laitiers',
-  'Épicerie',
-  'Boissons',
-  'Autres'
-];
-
-const seasons = ['été', 'hiver', 'toute l\'année'];
-
-const healthTypes = ['healthy', 'normal', 'gras'];
-const difficulties = [1, 2, 3];
-
-//pour les options d'affichage de date dans la liste de menu
-let options = {
-  weekday: "long",
-  year: "numeric",
-  month: "long",
-  day: "numeric",
-};
-
-// Fonction d'initialisation
 function initialize() {
-  loadFromLocalStorage();
-  // Navigation
+  const data = loadFromLocalStorage();
+  setRecipes(data.recipes);
+  setListMenuList(data.listMenuList);
+
   document.querySelectorAll('.tab-link').forEach(link => {
     link.addEventListener('click', (e) => {
       e.preventDefault();
@@ -232,23 +18,17 @@ function initialize() {
     });
   });
 
-  // Modal
   const modal = document.getElementById('recipe-modal');
   const span = document.getElementsByClassName('close')[0];
-
-  span.onclick = function() {
-    modal.style.display = 'none';
-  }
-
-  window.onclick = function(event) {
+  span.onclick = () => { modal.style.display = 'none'; };
+  window.onclick = (event) => {
     if (event.target == modal) {
       modal.style.display = 'none';
     }
-  }
+  };
 
-  // Initial update
   updateRecipeList();
+  updateListMenuList();
 }
 
-// Appeler la fonction d'initialisation
 initialize();

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -1,7 +1,22 @@
+import { recipes, filteredRecipes } from './recipes.js';
+import { saveRecipesToLocalStorage, saveMenusToLocalStorage } from './storage.js';
+
+export let listMenuList = [];
+export function setListMenuList(data) { listMenuList = data; }
+export let menuList = { name: '', date: '', recipes: [], startDate: null, menu: [] };
+export let shoppingList = {};
+
 let startDateGlobal = null;// sert pour éviter de passer un paramètre à updateMenuList(), variable initialisé dans createMenuList()
 let menuListArray = [];
 let editingMenuIndex = null; // index de la liste de menu en cours d'édition
 let currentMenuDetailIndex = null; // index de la liste de menu actuellement affichée dans le modal
+
+export const options = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+};
 
 /*////////////////AFFICHE UNE FENETRE CONTEXTUELLE POUR CREER UN LISTE DE MENUS/////////////*/
    function addMenuList() {
@@ -360,8 +375,8 @@ function saveMenuList (){
   
 
   updateListMenuList ();
-  saveMenusToLocalStorage();
-  saveRecipesToLocalStorage();
+  saveMenusToLocalStorage(listMenuList, recipes);
+  saveRecipesToLocalStorage(recipes, listMenuList);
  
   //réinitialiser l'objet globale menuList pour pouvoir recréer une liste, attention à faire en dernier pour que la liste de shopping puisse se remplir
   menuList = { name: '', date: '', recipes: [], startDate: null, menu: [] };// Crée une nouvelle instance d'objet
@@ -586,8 +601,8 @@ function deleteMenuList (index){
     listMenuList.splice(index, 1);
     shoppingList = {};
     updateListMenuList();
-    saveMenusToLocalStorage();
-    saveRecipesToLocalStorage();
+    saveMenusToLocalStorage(listMenuList, recipes);
+    saveRecipesToLocalStorage(recipes, listMenuList);
     document.getElementById('recipe-modal').style.display = 'none';
   }
 
@@ -668,6 +683,45 @@ function updateMenusWithRecipe(oldName, newRecipe) {
   refreshCurrentMenuDetails();
 }
 
+export {
+  addMenuList,
+  getTodayDate,
+  calculateNumberOfDays,
+  createMenuList,
+  addToMenu,
+  randomMenuList,
+  addRecipeToMenu,
+  updateMenuList,
+  saveMenuList,
+  updateListMenuList,
+  showMenuListDetails,
+  editMenuList,
+  deleteMenuList,
+  removeFromMenu,
+  drag,
+  allowDrop,
+  drop,
+  updateMenusWithRecipe,
+  setListMenuList,
+  menuList,
+  listMenuList,
+  shoppingList,
+  options
+};
+
+window.addMenuList = addMenuList;
+window.addToMenu = addToMenu;
+window.saveMenuList = saveMenuList;
+window.showMenuListDetails = showMenuListDetails;
+window.editMenuList = editMenuList;
+window.deleteMenuList = deleteMenuList;
+window.addRecipeToMenu = addRecipeToMenu;
+window.removeFromMenu = removeFromMenu;
+window.drag = drag;
+window.allowDrop = allowDrop;
+window.drop = drop;
+window.generatePDF = generatePDF;
+window.randomMenuList = randomMenuList;
 
 // Affiche les listes de menus enregistrées lors du chargement
 updateListMenuList();

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -1,4 +1,25 @@
-   /*//////////METS A JOUR LA LISTE DES RECETTES A AFFICHER/////////*/ 
+import { saveRecipesToLocalStorage, saveMenusToLocalStorage } from './storage.js';
+import { listMenuList, updateMenusWithRecipe } from './menus.js';
+
+export let recipes = [];
+export function setRecipes(data) { recipes = data; }
+export let filteredRecipes = [];
+export function setFilteredRecipes(data) { filteredRecipes = data; }
+
+export const categories = [
+  'Fruits et Légumes',
+  'Viandes et Poissons',
+  'Produits Laitiers',
+  'Épicerie',
+  'Boissons',
+  'Autres'
+];
+
+export const seasons = ['été', 'hiver', "toute l'année"];
+export const healthTypes = ['healthy', 'normal', 'gras'];
+export const difficulties = [1, 2, 3];
+
+/*//////////METS A JOUR LA LISTE DES RECETTES A AFFICHER/////////*/
   function updateRecipeList(recipeArray) {
     
     const activeSection = document.querySelector('.tab-content.active');// Trouver la section active
@@ -58,7 +79,7 @@
     event.stopPropagation();
     recipes[index].favori = !recipes[index].favori;
     updateRecipeList();
-    saveRecipesToLocalStorage();
+    saveRecipesToLocalStorage(recipes, listMenuList);
   }
 
   /*///////////////TRIER EN FONCTION DU CRITERE///////////////*/
@@ -326,9 +347,9 @@
 
     }
 
-    updateRecipeList();
-    saveMenusToLocalStorage();
-    saveRecipesToLocalStorage();
+  updateRecipeList();
+  saveMenusToLocalStorage(listMenuList, recipes);
+  saveRecipesToLocalStorage(recipes, listMenuList);
     
     //document.getElementById('recipe-modal').style.display = 'none';
   }
@@ -343,8 +364,8 @@
       filteredRecipes = filteredRecipes.filter(i => i !== index).map(i => (i > index ? i - 1 : i));
       updateMenusWithRecipe(oldName, null);
       updateRecipeList();
-      saveMenusToLocalStorage();
-      saveRecipesToLocalStorage();
+      saveMenusToLocalStorage(listMenuList, recipes);
+      saveRecipesToLocalStorage(recipes, listMenuList);
       document.getElementById('recipe-modal').style.display = 'none';
     }
   }
@@ -410,4 +431,34 @@
       }
   }).join('');
   }
+
+export {
+  updateRecipeList,
+  toggleFavorite,
+  sortRecipes,
+  showRecipeDetails,
+  editRecipe,
+  addIngredientInputToEdit,
+  deleteIngredientInputToEdit,
+  deleteIngredient,
+  saveRecipe,
+  deleteRecipe,
+  searchRecipes,
+  showIngredientsInEditRecipe,
+  updateDeleteButtons,
+  formatName,
+  setRecipes,
+  setFilteredRecipes
+};
+
+window.updateRecipeList = updateRecipeList;
+window.toggleFavorite = toggleFavorite;
+window.sortRecipes = sortRecipes;
+window.showRecipeDetails = showRecipeDetails;
+window.editRecipe = editRecipe;
+window.deleteRecipe = deleteRecipe;
+window.searchRecipes = searchRecipes;
+window.addIngredientInputToEdit = addIngredientInputToEdit;
+window.deleteIngredientInputToEdit = deleteIngredientInputToEdit;
+window.deleteIngredient = deleteIngredient;
   

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -1,0 +1,33 @@
+export function recomputeUsageCounts(recipes, menus) {
+  recipes.forEach(r => r.usageCount = 0);
+  menus.forEach(list => {
+    list.recipes.forEach(rcp => {
+      const found = recipes.find(r => r.name === rcp.name);
+      if (found) found.usageCount += 1;
+    });
+  });
+}
+
+export function saveRecipesToLocalStorage(recipes, menus) {
+  recomputeUsageCounts(recipes, menus);
+  localStorage.setItem('recipes', JSON.stringify(recipes));
+}
+
+export function saveMenusToLocalStorage(menus, recipes) {
+  recomputeUsageCounts(recipes, menus);
+  localStorage.setItem('listMenuList', JSON.stringify(menus));
+}
+
+export function loadFromLocalStorage() {
+  const storedRecipes = localStorage.getItem('recipes');
+  const recipes = storedRecipes ? JSON.parse(storedRecipes) : [];
+  recipes.forEach(r => {
+    if (!r.ingredientNames) {
+      r.ingredientNames = r.ingredients.map(i => i.name);
+    }
+  });
+  const storedMenus = localStorage.getItem('listMenuList');
+  const listMenuList = storedMenus ? JSON.parse(storedMenus) : [];
+  recomputeUsageCounts(recipes, listMenuList);
+  return { recipes, listMenuList };
+}


### PR DESCRIPTION
## Summary
- modularize storage logic
- expose recipe helpers from `recipes.js`
- export menu management utilities from `menu.js`
- rewrite `main.js` to initialize modules
- load the main script as a module

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842b200b998832c8aa76a0d3590562c