### PR TITLE
Add basic tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "appli_course",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -704,22 +704,27 @@ export {
   updateMenusWithRecipe
 };
 
-window.addMenuList = addMenuList;
-window.addToMenu = addToMenu;
-window.saveMenuList = saveMenuList;
-window.showMenuListDetails = showMenuListDetails;
-window.editMenuList = editMenuList;
-window.deleteMenuList = deleteMenuList;
-window.addRecipeToMenu = addRecipeToMenu;
-window.removeFromMenu = removeFromMenu;
-window.drag = drag;
-window.allowDrop = allowDrop;
-window.drop = drop;
-window.generatePDF = generatePDF;
-window.randomMenuList = randomMenuList;
+if (typeof window !== 'undefined') {
+  window.addMenuList = addMenuList;
+  window.addToMenu = addToMenu;
+  window.saveMenuList = saveMenuList;
+  window.showMenuListDetails = showMenuListDetails;
+  window.editMenuList = editMenuList;
+  window.deleteMenuList = deleteMenuList;
+  window.addRecipeToMenu = addRecipeToMenu;
+  window.removeFromMenu = removeFromMenu;
+  window.drag = drag;
+  window.allowDrop = allowDrop;
+  window.drop = drop;
+  window.generatePDF = generatePDF;
+  window.randomMenuList = randomMenuList;
+}
 
 // Affiche les listes de menus enregistrées lors du chargement
-updateListMenuList();
+// N'exécute la mise à jour que si un environnement DOM est présent
+if (typeof document !== 'undefined') {
+  updateListMenuList();
+}
 
 
 

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -449,14 +449,16 @@ export {
   formatName
 };
 
-window.updateRecipeList = updateRecipeList;
-window.toggleFavorite = toggleFavorite;
-window.sortRecipes = sortRecipes;
-window.showRecipeDetails = showRecipeDetails;
-window.editRecipe = editRecipe;
-window.deleteRecipe = deleteRecipe;
-window.searchRecipes = searchRecipes;
-window.addIngredientInputToEdit = addIngredientInputToEdit;
-window.deleteIngredientInputToEdit = deleteIngredientInputToEdit;
-window.deleteIngredient = deleteIngredient;
-  
+
+if (typeof window !== 'undefined') {
+  window.updateRecipeList = updateRecipeList;
+  window.toggleFavorite = toggleFavorite;
+  window.sortRecipes = sortRecipes;
+  window.showRecipeDetails = showRecipeDetails;
+  window.editRecipe = editRecipe;
+  window.deleteRecipe = deleteRecipe;
+  window.searchRecipes = searchRecipes;
+  window.addIngredientInputToEdit = addIngredientInputToEdit;
+  window.deleteIngredientInputToEdit = deleteIngredientInputToEdit;
+  window.deleteIngredient = deleteIngredient;
+}

--- a/test/menu.test.js
+++ b/test/menu.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getTodayDate, calculateNumberOfDays } from '../scripts/menu.js';
+
+// Helper to format a Date object as YYYY-MM-DD
+function format(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+test('getTodayDate without parameter returns today', () => {
+  const expected = format(new Date());
+  assert.equal(getTodayDate(), expected);
+});
+
+test('getTodayDate with daysToAdd returns shifted date', () => {
+  const expectedDate = new Date();
+  expectedDate.setDate(expectedDate.getDate() + 2);
+  const expected = format(expectedDate);
+  assert.equal(getTodayDate(2), expected);
+});
+
+test('calculateNumberOfDays computes inclusive difference', () => {
+  const start = new Date('2023-01-01');
+  const end = new Date('2023-01-10');
+  assert.equal(calculateNumberOfDays(start, end), 10);
+});

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { recomputeUsageCounts } from '../scripts/storage.js';
+
+test('recomputeUsageCounts updates counts based on menus', () => {
+  const recipes = [
+    { name: 'R1', usageCount: 0 },
+    { name: 'R2', usageCount: 0 }
+  ];
+  const menus = [
+    { recipes: [{ name: 'R1' }, { name: 'R2' }] },
+    { recipes: [{ name: 'R1' }] }
+  ];
+  recomputeUsageCounts(recipes, menus);
+  assert.equal(recipes[0].usageCount, 2);
+  assert.equal(recipes[1].usageCount, 1);
+});
+
+test('recomputeUsageCounts resets counts when no menus', () => {
+  const recipes = [
+    { name: 'R1', usageCount: 5 }
+  ];
+  recomputeUsageCounts(recipes, []);
+  assert.equal(recipes[0].usageCount, 0);
+});


### PR DESCRIPTION
## Summary
- guard browser-specific code when running under Node
- add Node-based tests for menu and storage utilities
- configure test script in package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ced10544832cbda413f6c88a2488