### PR TITLE
Add comprehensive test suite

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,10 @@
+export function createLocalStorageMock() {
+  let store = {};
+  return {
+    setItem(key, value) { store[key] = String(value); },
+    getItem(key) { return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null; },
+    removeItem(key) { delete store[key]; },
+    clear() { store = {}; },
+    get store() { return store; }
+  };
+}

--- a/test/menu.test.js
+++ b/test/menu.test.js
@@ -27,3 +27,21 @@ test('calculateNumberOfDays computes inclusive difference', () => {
   const end = new Date('2023-01-10');
   assert.equal(calculateNumberOfDays(start, end), 10);
 });
+
+test('getTodayDate handles negative offsets', () => {
+  const expectedDate = new Date();
+  expectedDate.setDate(expectedDate.getDate() - 1);
+  const expected = format(expectedDate);
+  assert.equal(getTodayDate(-1), expected);
+});
+
+test('calculateNumberOfDays returns 1 when dates are equal', () => {
+  const date = new Date('2023-05-01');
+  assert.equal(calculateNumberOfDays(date, date), 1);
+});
+
+test('calculateNumberOfDays handles end before start', () => {
+  const start = new Date('2023-05-10');
+  const end = new Date('2023-05-05');
+  assert.equal(calculateNumberOfDays(start, end), -4);
+});

--- a/test/recipes.test.js
+++ b/test/recipes.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as Recipes from '../scripts/recipes.js';
+import { setListMenuList } from '../scripts/menu.js';
+import { createLocalStorageMock } from './helpers.js';
+
+const { toggleFavorite, sortRecipes, setRecipes, setFilteredRecipes } = Recipes;
+
+function mockDocument() {
+  const recipeList = { insertAdjacentHTML() {}, innerHTML: '' };
+  const activeSection = { querySelector: () => recipeList };
+  return {
+    querySelector: () => activeSection,
+    getElementById: () => null
+  };
+}
+
+test('toggleFavorite toggles value and saves', () => {
+  setRecipes([{ name: 'A', favori: false, usageCount: 0 }]);
+  setListMenuList([]);
+  const local = createLocalStorageMock();
+  globalThis.localStorage = local;
+  globalThis.document = mockDocument();
+  toggleFavorite(0, { stopPropagation() {} });
+  assert.equal(Recipes.recipes[0].favori, true);
+  const stored = JSON.parse(local.getItem('recipes'));
+  assert.equal(stored[0].favori, true);
+  delete globalThis.localStorage;
+  delete globalThis.document;
+});
+
+test('sortRecipes sorts alphabetically', () => {
+  setRecipes([
+    { name: 'B', usageCount: 1, rating: 3, favori: false },
+    { name: 'A', usageCount: 2, rating: 5, favori: true }
+  ]);
+  setFilteredRecipes([0,1]);
+  setListMenuList([]);
+  const recipeList = { insertAdjacentHTML() {}, innerHTML: '' };
+  const activeSection = { querySelector: () => recipeList };
+  globalThis.document = {
+    querySelector: () => activeSection,
+    getElementById: () => null
+  };
+  sortRecipes('alphabetical');
+  delete globalThis.document;
+  const indexA = recipeList.innerHTML.indexOf('>A<');
+  const indexB = recipeList.innerHTML.indexOf('>B<');
+  assert.ok(indexA !== -1 && indexB !== -1 && indexA < indexB);
+});

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { recomputeUsageCounts } from '../scripts/storage.js';
+import { recomputeUsageCounts, saveRecipesToLocalStorage, saveMenusToLocalStorage, loadFromLocalStorage } from '../scripts/storage.js';
+import { createLocalStorageMock } from './helpers.js';
 
 test('recomputeUsageCounts updates counts based on menus', () => {
   const recipes = [
@@ -22,4 +23,56 @@ test('recomputeUsageCounts resets counts when no menus', () => {
   ];
   recomputeUsageCounts(recipes, []);
   assert.equal(recipes[0].usageCount, 0);
+});
+
+test('saveRecipesToLocalStorage stores recipes with updated counts', () => {
+  const recipes = [
+    { name: 'R1', usageCount: 0 },
+    { name: 'R2', usageCount: 0 }
+  ];
+  const menus = [
+    { recipes: [{ name: 'R1' }, { name: 'R2' }] },
+    { recipes: [{ name: 'R1' }] }
+  ];
+  const local = createLocalStorageMock();
+  globalThis.localStorage = local;
+  saveRecipesToLocalStorage(recipes, menus);
+  const stored = JSON.parse(local.getItem('recipes'));
+  assert.equal(stored[0].usageCount, 2);
+  assert.equal(stored[1].usageCount, 1);
+  delete globalThis.localStorage;
+});
+
+test('saveMenusToLocalStorage stores menus and updates recipe counts', () => {
+  const recipes = [
+    { name: 'R1', usageCount: 0 },
+    { name: 'R2', usageCount: 0 }
+  ];
+  const menus = [
+    { recipes: [{ name: 'R1' }, { name: 'R2' }] },
+    { recipes: [{ name: 'R1' }] }
+  ];
+  const local = createLocalStorageMock();
+  globalThis.localStorage = local;
+  saveMenusToLocalStorage(menus, recipes);
+  const stored = JSON.parse(local.getItem('listMenuList'));
+  assert.equal(stored.length, 2);
+  assert.equal(recipes[0].usageCount, 2);
+  assert.equal(recipes[1].usageCount, 1);
+  delete globalThis.localStorage;
+});
+
+test('loadFromLocalStorage rebuilds ingredientNames and counts', () => {
+  const local = createLocalStorageMock();
+  const recipes = [
+    { name: 'R1', ingredients: [{ name: 'Ing1' }], usageCount: 0 }
+  ];
+  const menus = [ { recipes: [{ name: 'R1' }] } ];
+  local.setItem('recipes', JSON.stringify(recipes));
+  local.setItem('listMenuList', JSON.stringify(menus));
+  globalThis.localStorage = local;
+  const data = loadFromLocalStorage();
+  assert.deepEqual(data.recipes[0].ingredientNames, ['Ing1']);
+  assert.equal(data.recipes[0].usageCount, 1);
+  delete globalThis.localStorage;
 });


### PR DESCRIPTION
## Summary
- add helper for mocking localStorage
- expand menu utility tests for edge cases
- cover storage helpers with localStorage behavior
- add recipe module tests for favorites and sorting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d32a5c5c832ca3b03a4e7dfd587d