### PR TITLE
Update recipe card visuals

### DIFF
--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -59,20 +59,20 @@ export const difficulties = [1, 2, 3];
     recipeList.innerHTML = recipesToDisplay.map((recipe) => {
       const realIndex = recipes.indexOf(recipe);
       const imageSrc = recipe.image || 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+      const difficultyIcons = Array.from({ length: recipe.difficulty }).map(() => '<i class="fa-solid fa-utensils"></i>').join('');
       return `
       <div class="recipe-card ${recipe.favori ? 'favori' : ''}" onclick="showRecipeDetails(${realIndex})">
         <img src="${imageSrc}" class="recipe-image" alt="${recipe.name}">
-        <div class="recipe-overlay">
-          <span class="recipe-rating">${'★'.repeat(recipe.rating)}</span>
+        <div class="recipe-overlay recipe-tags">
+          <span class="tag">${recipe.season}</span>
+          <span class="tag">${recipe.health}</span>
+          <span class="tag">${recipe.usageCount}</span>
+          <span class="tag recipe-difficulty">${difficultyIcons}</span>
         </div>
-        <span class="recipe-favori" onclick="toggleFavorite(${realIndex}, event)"><i class="fa-solid fa-hat-chef"></i></span>
+        <span class="recipe-favori" onclick="toggleFavorite(${realIndex}, event)"><i class="fa-solid fa-heart"></i></span>
         <div class="recipe-info">
-          <h3 class="recipe-name">${recipe.name} <span class="recipe-difficulty">${'🍴'.repeat(recipe.difficulty)}</span></h3>
-          <div class="recipe-tags">
-            <span class="tag">${recipe.season}</span>
-            <span class="tag">${recipe.health}</span>
-            <span class="tag">${recipe.usageCount}</span>
-          </div>
+          <h3 class="recipe-name">${recipe.name}</h3>
+          <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
         </div>
       </div>
     `;
@@ -404,22 +404,22 @@ export const difficulties = [1, 2, 3];
     recipeList.innerHTML = filteredRecipes.map((recipeIndex) => {
       const recipe = recipes[recipeIndex];
       const imageSrc = recipe.image || 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+      const difficultyIcons = Array.from({ length: recipe.difficulty }).map(() => '<i class="fa-solid fa-utensils"></i>').join('');
 
       if (sectionId === 'recipe-modal') {
           return `
               <div class="recipe-card ${recipe.favori ? 'favori' : ''}">
                   <img src="${imageSrc}" class="recipe-image" alt="${recipe.name}">
-                  <div class="recipe-overlay">
-                      <span class="recipe-rating">${'★'.repeat(recipe.rating)}</span>
+                  <div class="recipe-overlay recipe-tags">
+                      <span class="tag">${recipe.season}</span>
+                      <span class="tag">${recipe.health}</span>
+                      <span class="tag">${recipe.usageCount}</span>
+                      <span class="tag recipe-difficulty">${difficultyIcons}</span>
                   </div>
-                  <span class="recipe-favori" onclick="toggleFavorite(${recipeIndex}, event)"><i class="fa-solid fa-hat-chef"></i></span>
+                  <span class="recipe-favori" onclick="toggleFavorite(${recipeIndex}, event)"><i class="fa-solid fa-heart"></i></span>
                   <div class="recipe-info">
-                      <h3 class="recipe-name">${recipe.name} <span class="recipe-difficulty">${'🍴'.repeat(recipe.difficulty)}</span></h3>
-                      <div class="recipe-tags">
-                        <span class="tag">${recipe.season}</span>
-                        <span class="tag">${recipe.health}</span>
-                        <span class="tag">${recipe.usageCount}</span>
-                      </div>
+                      <h3 class="recipe-name">${recipe.name}</h3>
+                      <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
                   </div>
                   <button onclick="addRecipeToMenu(${recipeIndex})">Ajouter au Menu</button>
               </div>
@@ -428,17 +428,16 @@ export const difficulties = [1, 2, 3];
           return `
               <div class="recipe-card ${recipe.favori ? 'favori' : ''}" onclick="showRecipeDetails(${recipeIndex})">
                   <img src="${imageSrc}" class="recipe-image" alt="${recipe.name}">
-                  <div class="recipe-overlay">
-                      <span class="recipe-rating">${'★'.repeat(recipe.rating)}</span>
+                  <div class="recipe-overlay recipe-tags">
+                      <span class="tag">${recipe.season}</span>
+                      <span class="tag">${recipe.health}</span>
+                      <span class="tag">${recipe.usageCount}</span>
+                      <span class="tag recipe-difficulty">${difficultyIcons}</span>
                   </div>
-                  <span class="recipe-favori" onclick="toggleFavorite(${recipeIndex}, event)"><i class="fa-solid fa-hat-chef"></i></span>
+                  <span class="recipe-favori" onclick="toggleFavorite(${recipeIndex}, event)"><i class="fa-solid fa-heart"></i></span>
                   <div class="recipe-info">
-                      <h3 class="recipe-name">${recipe.name} <span class="recipe-difficulty">${'🍴'.repeat(recipe.difficulty)}</span></h3>
-                      <div class="recipe-tags">
-                        <span class="tag">${recipe.season}</span>
-                        <span class="tag">${recipe.health}</span>
-                        <span class="tag">${recipe.usageCount}</span>
-                      </div>
+                      <h3 class="recipe-name">${recipe.name}</h3>
+                      <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
                   </div>
               </div>
           `;

--- a/styles.css
+++ b/styles.css
@@ -198,12 +198,11 @@ body {
   .recipe-overlay {
     position: absolute;
     top: 8px;
-    left: 8px;
-    display: flex;
+    right: 8px;
+    display: grid;
+    grid-template-columns: repeat(2, auto);
     gap: 4px;
-    font-size: 1.3em;
-    color: #FFD700;
-    text-shadow: 0 0 2px #000;
+    justify-items: end;
   }
 
   .recipe-favori {
@@ -239,16 +238,32 @@ body {
     margin: 0;
     display: flex;
     align-items: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .recipe-rating {
+    color: #FFD700;
+    text-shadow: 0 0 2px #000;
+    font-size: 1.1em;
+    margin-top: 4px;
   }
 
   .recipe-tags {
-    display: flex;
-    gap: 5px;
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+    gap: 4px;
+    justify-items: end;
     margin-top: 4px;
   }
 
   .recipe-difficulty {
-    margin-left: 6px;
+    margin-left: 0;
+  }
+
+  .recipe-difficulty i {
+    color: #fff;
   }
 
   .tag {


### PR DESCRIPTION
## Summary
- show recipe tags in overlay grid
- move rating below recipe title
- truncate long recipe names
- make difficulty a white utensil tag
- replace favorite icon with a heart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68481aa3bd6c832c811e917f631d753d