### PR TITLE
Update recipe cards layout

### DIFF
--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -63,16 +63,18 @@ export const difficulties = [1, 2, 3];
       return `
       <div class="recipe-card ${recipe.favori ? 'favori' : ''}" onclick="showRecipeDetails(${realIndex})">
         <img src="${imageSrc}" class="recipe-image" alt="${recipe.name}">
-        <div class="recipe-overlay recipe-tags">
-          <span class="tag">${recipe.season}</span>
-          <span class="tag">${recipe.health}</span>
-          <span class="tag">${recipe.usageCount}</span>
-          <span class="tag recipe-difficulty">${difficultyIcons}</span>
-        </div>
         <span class="recipe-favori" onclick="toggleFavorite(${realIndex}, event)"><i class="fa-solid fa-heart"></i></span>
         <div class="recipe-info">
-          <h3 class="recipe-name">${recipe.name}</h3>
-          <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
+          <div class="recipe-details">
+            <h3 class="recipe-name">${recipe.name}</h3>
+            <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
+          </div>
+          <div class="recipe-tags">
+            <span class="tag">${recipe.season}</span>
+            <span class="tag">${recipe.health}</span>
+            <span class="tag">${recipe.usageCount}</span>
+            <span class="tag recipe-difficulty">${difficultyIcons}</span>
+          </div>
         </div>
       </div>
     `;
@@ -410,16 +412,18 @@ export const difficulties = [1, 2, 3];
           return `
               <div class="recipe-card ${recipe.favori ? 'favori' : ''}">
                   <img src="${imageSrc}" class="recipe-image" alt="${recipe.name}">
-                  <div class="recipe-overlay recipe-tags">
-                      <span class="tag">${recipe.season}</span>
-                      <span class="tag">${recipe.health}</span>
-                      <span class="tag">${recipe.usageCount}</span>
-                      <span class="tag recipe-difficulty">${difficultyIcons}</span>
-                  </div>
                   <span class="recipe-favori" onclick="toggleFavorite(${recipeIndex}, event)"><i class="fa-solid fa-heart"></i></span>
                   <div class="recipe-info">
-                      <h3 class="recipe-name">${recipe.name}</h3>
-                      <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
+                      <div class="recipe-details">
+                          <h3 class="recipe-name">${recipe.name}</h3>
+                          <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
+                      </div>
+                      <div class="recipe-tags">
+                          <span class="tag">${recipe.season}</span>
+                          <span class="tag">${recipe.health}</span>
+                          <span class="tag">${recipe.usageCount}</span>
+                          <span class="tag recipe-difficulty">${difficultyIcons}</span>
+                      </div>
                   </div>
                   <button onclick="addRecipeToMenu(${recipeIndex})">Ajouter au Menu</button>
               </div>
@@ -428,16 +432,18 @@ export const difficulties = [1, 2, 3];
           return `
               <div class="recipe-card ${recipe.favori ? 'favori' : ''}" onclick="showRecipeDetails(${recipeIndex})">
                   <img src="${imageSrc}" class="recipe-image" alt="${recipe.name}">
-                  <div class="recipe-overlay recipe-tags">
-                      <span class="tag">${recipe.season}</span>
-                      <span class="tag">${recipe.health}</span>
-                      <span class="tag">${recipe.usageCount}</span>
-                      <span class="tag recipe-difficulty">${difficultyIcons}</span>
-                  </div>
                   <span class="recipe-favori" onclick="toggleFavorite(${recipeIndex}, event)"><i class="fa-solid fa-heart"></i></span>
                   <div class="recipe-info">
-                      <h3 class="recipe-name">${recipe.name}</h3>
-                      <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
+                      <div class="recipe-details">
+                          <h3 class="recipe-name">${recipe.name}</h3>
+                          <div class="recipe-rating">${'★'.repeat(recipe.rating)}</div>
+                      </div>
+                      <div class="recipe-tags">
+                          <span class="tag">${recipe.season}</span>
+                          <span class="tag">${recipe.health}</span>
+                          <span class="tag">${recipe.usageCount}</span>
+                          <span class="tag recipe-difficulty">${difficultyIcons}</span>
+                      </div>
                   </div>
               </div>
           `;

--- a/styles.css
+++ b/styles.css
@@ -195,15 +195,6 @@ body {
     display: block;
   }
 
-  .recipe-overlay {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    display: grid;
-    grid-template-columns: repeat(2, auto);
-    gap: 4px;
-    justify-items: end;
-  }
 
   .recipe-favori {
     position: absolute;
@@ -232,6 +223,14 @@ body {
     color: #8CD1E8;
     padding: 5px;
     box-sizing: border-box;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .recipe-details {
+    display: flex;
+    flex-direction: column;
   }
 
   .recipe-name {
@@ -255,7 +254,7 @@ body {
     grid-template-columns: repeat(2, auto);
     gap: 4px;
     justify-items: end;
-    margin-top: 4px;
+    margin-top: 0;
   }
 
   .recipe-difficulty {


### PR DESCRIPTION
## Summary
- display recipe tags in the bottom overlay
- tweak CSS layout for recipe info

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68481dcdef84832c9c947795a3a0e044