### PR TITLE
Fix recipe card interactions

### DIFF
--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -410,7 +410,7 @@ export const difficulties = [1, 2, 3];
 
       if (sectionId === 'recipe-modal') {
           return `
-              <div class="recipe-card ${recipe.favori ? 'favori' : ''}">
+              <div class="recipe-card ${recipe.favori ? 'favori' : ''}" onclick="addRecipeToMenu(${recipeIndex})">
                   <img src="${imageSrc}" class="recipe-image" alt="${recipe.name}">
                   <span class="recipe-favori" onclick="toggleFavorite(${recipeIndex}, event)"><i class="fa-solid fa-heart"></i></span>
                   <div class="recipe-info">
@@ -425,7 +425,6 @@ export const difficulties = [1, 2, 3];
                           <span class="tag recipe-difficulty">${difficultyIcons}</span>
                       </div>
                   </div>
-                  <button onclick="addRecipeToMenu(${recipeIndex})">Ajouter au Menu</button>
               </div>
           `;
       } else {

--- a/styles.css
+++ b/styles.css
@@ -231,6 +231,8 @@ body {
   .recipe-details {
     display: flex;
     flex-direction: column;
+    flex: 1;
+    min-width: 0;
   }
 
   .recipe-name {
@@ -254,6 +256,7 @@ body {
     gap: 4px;
     justify-items: end;
     margin-top: 0;
+    flex-shrink: 0;
   }
 
   .recipe-difficulty {


### PR DESCRIPTION
## Summary
- make recipe cards in the modal add recipes on click
- prevent recipe name from overlapping tags using flexbox

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848245523a0832cbd34b55da45c1522