### PR TITLE
Enable slot-based recipe assignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
     <div id="menu-list" class="tab-content">
       <h1>Liste de Menus</h1>
       <button id="creerListMenu" onclick="addMenuList()">Créer une liste de menu</button>
-      <button id="add-recipe-button" type="button" class="hidden" onclick="addToMenu()">Ajouter une recette au menu</button>
       <button id="save-menu-list-button" type="button" class="hidden" onclick="saveMenuList()">Sauvegarder la liste de menu</button>
+      <button id="chef-menu-button" type="button" class="hidden" onclick="randomMenuList()">Menu du chef</button>
       <div id="menu-form-container" class="hidden"></div>
       <div id="menu-list-jours"></div>
       <div id="menu-items" class="recipe-list-menu"></div>

--- a/styles.css
+++ b/styles.css
@@ -180,6 +180,18 @@ body {
     overflow: hidden;
     height: 200px;
   }
+  .delete-cross {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    color: red;
+    font-weight: bold;
+    cursor: pointer;
+    z-index: 2;
+  }
+  .delete-cross:hover {
+    color: darkred;
+  }
   .recipe-card:hover {
     transform: translateY(-5px);
   }


### PR DESCRIPTION
## Summary
- add "Menu du chef" button and drop add-recipe button
- style delete cross for menu slots
- open recipe modal directly by clicking on a slot
- allow replacing a recipe in a slot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68482e47b2f0832cb782636648cef8ce