### PR TITLE
Improve menu slot layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
     <div id="menu-list" class="tab-content">
       <h1>Liste de Menus</h1>
       <button id="creerListMenu" onclick="addMenuList()">Créer une liste de menu</button>
-      <button id="save-menu-list-button" type="button" class="hidden" onclick="saveMenuList()">Sauvegarder la liste de menu</button>
       <button id="chef-menu-button" type="button" class="hidden" onclick="randomMenuList()">Menu du chef</button>
+      <button id="save-menu-list-button" type="button" class="hidden" onclick="saveMenuList()">Sauvegarder la liste de menu</button>
       <div id="menu-form-container" class="hidden"></div>
       <div id="menu-list-jours"></div>
       <div id="menu-items" class="recipe-list-menu"></div>

--- a/styles.css
+++ b/styles.css
@@ -164,8 +164,11 @@ body {
     background-color: white;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    padding: 15px;
-    padding-bottom: 100px;
+    padding: 10px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
     transition: transform 0.3s;
     overflow: hidden;
@@ -180,6 +183,22 @@ body {
     overflow: hidden;
     height: 200px;
   }
+
+  .recipe-slot .recipe-card {
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: grab;
+  }
+
+  .recipe-slot h5 {
+    font-size: 1.1em;
+    margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .delete-cross {
     position: absolute;
     top: 4px;
@@ -188,6 +207,7 @@ body {
     font-weight: bold;
     cursor: pointer;
     z-index: 2;
+    font-size: 1.4em;
   }
   .delete-cross:hover {
     color: darkred;
@@ -332,11 +352,16 @@ body {
 .menu-plan-table td {
   border: 1px solid #ddd;
   padding: 4px;
-  max-width: 150px;
+  max-width: 180px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: top;
+}
+
+.recipe-slot {
+  width: 100%;
+  height: 60px;
 }
 .menu-plan-table th {
   background-color: #f5f5f5;


### PR DESCRIPTION
## Summary
- swap order of menu buttons
- make menu slots fixed size
- enlarge delete icon and truncate recipe titles
- widen menu table columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684831a66e94832c8d28499bfffb2247