### PR TITLE
Add slider toggles and new value descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,57 +60,63 @@
         <div id="chef-settings-sliders">
           <div class="slider-group">
             <label for="chef-difficulty-slider">Difficulté</label>
+            <label class="inline"><input type="checkbox" id="chef-difficulty-enabled" checked> ON</label>
             <div class="slider-wrapper">
               <span class="slider-label-left">Facile</span>
               <input type="range" id="chef-difficulty-slider" min="0" max="100" step="10" value="50">
               <span class="slider-label-right">Difficile</span>
             </div>
-            <div class="slider-value" id="chef-difficulty-value">Aléatoire</div>
+            <div class="slider-value" id="chef-difficulty-value">50/50</div>
           </div>
           <div class="slider-group">
             <label for="chef-rating-slider">Note</label>
+            <label class="inline"><input type="checkbox" id="chef-rating-enabled" checked> ON</label>
             <div class="slider-wrapper">
               <span class="slider-label-left">Basse</span>
               <input type="range" id="chef-rating-slider" min="0" max="100" step="10" value="50">
               <span class="slider-label-right">Haute</span>
             </div>
-            <div class="slider-value" id="chef-rating-value">Aléatoire</div>
+            <div class="slider-value" id="chef-rating-value">50/50</div>
           </div>
           <div class="slider-group">
             <label for="chef-usage-slider">Utilisations</label>
+            <label class="inline"><input type="checkbox" id="chef-usage-enabled" checked> ON</label>
             <div class="slider-wrapper">
               <span class="slider-label-left">Rare</span>
               <input type="range" id="chef-usage-slider" min="0" max="100" step="10" value="50">
               <span class="slider-label-right">Souvent</span>
             </div>
-            <div class="slider-value" id="chef-usage-value">Aléatoire</div>
+            <div class="slider-value" id="chef-usage-value">50/50</div>
           </div>
           <div class="slider-group">
             <label for="chef-type-slider">Type</label>
+            <label class="inline"><input type="checkbox" id="chef-type-enabled" checked> ON</label>
             <div class="slider-wrapper">
               <span class="slider-label-left">Healthy</span>
               <input type="range" id="chef-type-slider" min="0" max="100" step="10" value="50">
               <span class="slider-label-right">Gras</span>
             </div>
-            <div class="slider-value" id="chef-type-value">Aléatoire</div>
+            <div class="slider-value" id="chef-type-value">50/50</div>
           </div>
           <div class="slider-group">
             <label for="chef-favorite-slider">Favoris</label>
+            <label class="inline"><input type="checkbox" id="chef-favorite-enabled" checked> ON</label>
             <div class="slider-wrapper">
               <span class="slider-label-left">Indifférent</span>
               <input type="range" id="chef-favorite-slider" min="0" max="100" step="10" value="50">
               <span class="slider-label-right">Favori</span>
             </div>
-            <div class="slider-value" id="chef-favorite-value">Aléatoire</div>
+            <div class="slider-value" id="chef-favorite-value">50/50</div>
           </div>
           <div class="slider-group">
             <label for="chef-season-slider">Saison</label>
+            <label class="inline"><input type="checkbox" id="chef-season-enabled" checked> ON</label>
             <div class="slider-wrapper">
               <span class="slider-label-left">Hiver</span>
               <input type="range" id="chef-season-slider" min="0" max="100" step="10" value="50">
               <span class="slider-label-right">Été</span>
             </div>
-            <div class="slider-value" id="chef-season-value">Aléatoire</div>
+            <div class="slider-value" id="chef-season-value">50/50</div>
             <label class="inline"><input type="checkbox" id="chef-season-all-year" checked> Inclure les recettes toute l'année</label>
           </div>
         </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -40,12 +40,37 @@ function initialize() {
     randomBox.addEventListener('change', toggle);
     toggle();
 
+    // enable/disable sliders based on per-slider switches
+    sliders.querySelectorAll('input[type="checkbox"][id$="-enabled"]').forEach(cb => {
+      const slider = document.getElementById(cb.id.replace('-enabled', '-slider'));
+      if (!slider) return;
+      function toggleSlider() {
+        slider.disabled = !cb.checked;
+      }
+      cb.addEventListener('change', toggleSlider);
+      toggleSlider();
+    });
+
+    const phrases = ['l\xE9g\xE8rement plus', 'un peu plus', 'plus', 'beaucoup plus'];
+
     sliders.querySelectorAll('input[type="range"]').forEach(slider => {
       const output = document.getElementById(slider.id.replace('-slider', '-value'));
+      const left = slider.parentElement.querySelector('.slider-label-left')?.textContent.trim() || '';
+      const right = slider.parentElement.querySelector('.slider-label-right')?.textContent.trim() || '';
       function update() {
         if (!output) return;
         const val = parseInt(slider.value, 10);
-        output.textContent = val === 50 ? 'Aléatoire' : val;
+        const diff = Math.abs(val - 50) / 10;
+        if (diff === 0) {
+          output.textContent = '50/50';
+        } else {
+          const label = val < 50 ? left : right;
+          if (diff >= 5) {
+            output.textContent = label;
+          } else {
+            output.textContent = `${phrases[diff - 1]} ${label}`;
+          }
+        }
       }
       slider.addEventListener('input', update);
       update();

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -209,14 +209,15 @@ function getChefMenuPrefs() {
   const box = document.getElementById('chef-random-checkbox');
   if (!box) return { random: true };
   const val = id => document.getElementById(id)?.value || 50;
+  const enabled = id => document.getElementById(id)?.checked ?? true;
   return {
     random: box.checked,
-    difficulty: parseInt(val('chef-difficulty-slider'), 10) / 100,
-    rating: parseInt(val('chef-rating-slider'), 10) / 100,
-    usage: parseInt(val('chef-usage-slider'), 10) / 100,
-    type: parseInt(val('chef-type-slider'), 10) / 100,
-    favorite: parseInt(val('chef-favorite-slider'), 10) / 100,
-    season: parseInt(val('chef-season-slider'), 10) / 100,
+    difficulty: parseInt(enabled('chef-difficulty-enabled') ? val('chef-difficulty-slider') : 50, 10) / 100,
+    rating: parseInt(enabled('chef-rating-enabled') ? val('chef-rating-slider') : 50, 10) / 100,
+    usage: parseInt(enabled('chef-usage-enabled') ? val('chef-usage-slider') : 50, 10) / 100,
+    type: parseInt(enabled('chef-type-enabled') ? val('chef-type-slider') : 50, 10) / 100,
+    favorite: parseInt(enabled('chef-favorite-enabled') ? val('chef-favorite-slider') : 50, 10) / 100,
+    season: parseInt(enabled('chef-season-enabled') ? val('chef-season-slider') : 50, 10) / 100,
     allYear: document.getElementById('chef-season-all-year')?.checked ?? true
   };
 }


### PR DESCRIPTION
## Summary
- add ON/OFF switches for each chef menu slider
- show `50/50` by default and use descriptive phrases as slider values
- ignore preferences when switches are off

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68483f75f490832c9b097d0dec6128a4