### PR TITLE
Refactor date helpers and add menu update tests

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -1,5 +1,6 @@
 import { recipes, filteredRecipes, setFilteredRecipes } from './recipes.js';
 import { saveRecipesToLocalStorage, saveMenusToLocalStorage } from './storage.js';
+import { formatDate } from './utils.js';
 
 export let listMenuList = [];
 export function setListMenuList(data) { listMenuList = data; }
@@ -56,19 +57,11 @@ export const options = {
   
   /*////////////////RETOURNE LA DATE DU JOUR OU SI ARGUMENT DATE DU JOUR + JOUR A AJOUTER ////////////////*/
   function getTodayDate(daysToAdd) {
-    const today = new Date(); // Date du jour
-    const newDate = new Date(today); // Créer une copie de la date du jour
-
-    // Ajouter des jours si daysToAdd est défini, sinon ne rien ajouter
+    const date = new Date();
     if (daysToAdd !== undefined && daysToAdd !== null) {
-        newDate.setDate(today.getDate() + daysToAdd);
+      date.setDate(date.getDate() + daysToAdd);
     }
-    // Formater la date au format YYYY-MM-DD
-    const year = newDate.getFullYear();
-    const month = String(newDate.getMonth() + 1).padStart(2, '0'); // Mois entre 01 et 12
-    const day = String(newDate.getDate()).padStart(2, '0'); // Jour entre 01 et 31
-    
-    return `${year}-${month}-${day}`;
+    return formatDate(date);
   }
   
   /*////////////////CALCULE LE NB DE JOUR POUR LA LISTE DE MENU////////////////*/
@@ -750,10 +743,12 @@ function updateMenusWithRecipe(oldName, newRecipe) {
   }));
 
   // Mettre à jour l'affichage et la liste d'ingrédients si nécessaire
-  updateMenuList();
-  updateListMenuList();
-  updateCurrentShoppingList();
-  refreshCurrentMenuDetails();
+  if (typeof document !== 'undefined') {
+    updateMenuList();
+    updateListMenuList();
+    updateCurrentShoppingList();
+    refreshCurrentMenuDetails();
+  }
 }
 
 export {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,6 @@
+export function formatDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/test/menu.test.js
+++ b/test/menu.test.js
@@ -1,24 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { getTodayDate, calculateNumberOfDays } from '../scripts/menu.js';
-
-// Helper to format a Date object as YYYY-MM-DD
-function format(date) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
+import { formatDate } from '../scripts/utils.js';
 
 test('getTodayDate without parameter returns today', () => {
-  const expected = format(new Date());
+  const expected = formatDate(new Date());
   assert.equal(getTodayDate(), expected);
 });
 
 test('getTodayDate with daysToAdd returns shifted date', () => {
   const expectedDate = new Date();
   expectedDate.setDate(expectedDate.getDate() + 2);
-  const expected = format(expectedDate);
+  const expected = formatDate(expectedDate);
   assert.equal(getTodayDate(2), expected);
 });
 
@@ -31,7 +24,7 @@ test('calculateNumberOfDays computes inclusive difference', () => {
 test('getTodayDate handles negative offsets', () => {
   const expectedDate = new Date();
   expectedDate.setDate(expectedDate.getDate() - 1);
-  const expected = format(expectedDate);
+  const expected = formatDate(expectedDate);
   assert.equal(getTodayDate(-1), expected);
 });
 

--- a/test/updateMenus.test.js
+++ b/test/updateMenus.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateMenusWithRecipe, setListMenuList, listMenuList, menuList } from '../scripts/menu.js';
+
+// Utility to deep clone objects
+function clone(obj) { return JSON.parse(JSON.stringify(obj)); }
+
+test('updateMenusWithRecipe replaces recipe across menus', () => {
+  const initial = [{ recipes: [{ name: 'Old' }], menu: [[{ name: 'Old' }]] }];
+  setListMenuList(clone(initial));
+  menuList.recipes = [{ name: 'Old' }];
+  menuList.menu = [[{ name: 'Old' }]];
+
+  const newRecipe = { name: 'New' };
+  updateMenusWithRecipe('Old', newRecipe);
+
+  assert.equal(listMenuList[0].recipes[0].name, 'New');
+  assert.equal(listMenuList[0].menu[0][0].name, 'New');
+  assert.equal(menuList.recipes[0].name, 'New');
+});
+
+test('updateMenusWithRecipe removes recipe when null', () => {
+  const initial = [{ recipes: [{ name: 'Old' }], menu: [[{ name: 'Old' }, null]] }];
+  setListMenuList(clone(initial));
+  menuList.recipes = [{ name: 'Old' }];
+  menuList.menu = [[{ name: 'Old' }]];
+
+  updateMenusWithRecipe('Old', null);
+
+  assert.equal(listMenuList[0].recipes.length, 0);
+  assert.equal(listMenuList[0].menu[0][0], null);
+  assert.equal(menuList.recipes.length, 0);
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDate } from '../scripts/utils.js';
+
+test('formatDate returns YYYY-MM-DD string', () => {
+  const date = new Date('2023-05-04');
+  assert.equal(formatDate(date), '2023-05-04');
+});
+


### PR DESCRIPTION
## Summary
- centralize date formatting in `scripts/utils.js`
- use new `formatDate` helper in `menu.js` and tests
- guard DOM updates in `updateMenusWithRecipe`
- add tests for `updateMenusWithRecipe` and `formatDate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68484d811c4c832c805ba6f0f0d57a9e