### PR TITLE
Add chef menu carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,11 @@
 
     <div id="menu-list" class="tab-content">
       <h1>Liste de Menus</h1>
+      <div id="chef-carousel" class="carousel">
+        <button id="carousel-prev" type="button">&#9664;</button>
+        <div id="carousel-inner" class="carousel-inner"></div>
+        <button id="carousel-next" type="button">&#9654;</button>
+      </div>
       <button id="creerListMenu" onclick="addMenuList()">Créer une liste de menu</button>
       <button id="chef-menu-button" type="button" class="hidden" onclick="randomMenuList()">Menu du chef</button>
       <button id="save-menu-list-button" type="button" class="hidden" onclick="saveMenuList()">Sauvegarder la liste de menu</button>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,6 @@
 import { loadFromLocalStorage } from './storage.js';
 import { setRecipes, updateRecipeList } from './recipes.js';
-import { setListMenuList, updateListMenuList } from './menu.js';
+import { setListMenuList, updateListMenuList, updateChefCarousel } from './menu.js';
 
 function initialize() {
   const data = loadFromLocalStorage();
@@ -29,6 +29,7 @@ function initialize() {
 
   updateRecipeList();
   updateListMenuList();
+  updateChefCarousel();
 
   const randomBox = document.getElementById('chef-random-checkbox');
   const sliders = document.getElementById('chef-settings-sliders');
@@ -36,6 +37,7 @@ function initialize() {
     function toggle() {
       if (randomBox.checked) sliders.classList.add('disabled');
       else sliders.classList.remove('disabled');
+      updateChefCarousel();
     }
     randomBox.addEventListener('change', toggle);
     toggle();
@@ -46,6 +48,7 @@ function initialize() {
       if (!slider) return;
       function toggleSlider() {
         slider.disabled = !cb.checked;
+        updateChefCarousel();
       }
       cb.addEventListener('change', toggleSlider);
       toggleSlider();
@@ -72,8 +75,20 @@ function initialize() {
           }
         }
       }
-      slider.addEventListener('input', update);
+      slider.addEventListener('input', () => { update(); updateChefCarousel(); });
       update();
+    });
+  }
+
+  const prev = document.getElementById('carousel-prev');
+  const next = document.getElementById('carousel-next');
+  const inner = document.getElementById('carousel-inner');
+  if (prev && next && inner) {
+    prev.addEventListener('click', () => {
+      inner.scrollLeft -= 160;
+    });
+    next.addEventListener('click', () => {
+      inner.scrollLeft += 160;
     });
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -518,3 +518,50 @@ body {
   white-space: nowrap;
 }
 
+/* Carousel for chef suggestions */
+.carousel {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+.carousel-inner {
+  display: flex;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  gap: 10px;
+  padding: 10px 40px;
+}
+
+.carousel-inner::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(76, 175, 80, 0.8);
+  border: none;
+  color: #fff;
+  padding: 5px 10px;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.carousel button:hover {
+  background: #4CAF50;
+}
+
+#carousel-prev {
+  left: 0;
+}
+
+#carousel-next {
+  right: 0;
+}
+
+.carousel-card {
+  flex: 0 0 150px;
+  height: 180px;
+}
+


### PR DESCRIPTION
## Summary
- add chef carousel section in menu list page
- style carousel container and cards
- generate random suggestions based on chef parameters
- enable drag-and-drop from carousel to slots
- update carousel when parameters or menus change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684851e1a998832cbf895020eb96f80a