### PR TITLE
UI updates for menu lists and recipe form

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
       </div>
       <button id="creerListMenu" onclick="addMenuList()">Créer une liste de menu</button>
       <button id="chef-menu-button" type="button" class="hidden" onclick="randomMenuList()">Menu du chef</button>
+      <button id="clear-menu-recipes-button" type="button" class="hidden" onclick="clearMenuRecipes()">Supprimer les recettes</button>
       <button id="save-menu-list-button" type="button" class="hidden" onclick="saveMenuList()">Sauvegarder la liste de menu</button>
       <div id="menu-form-container" class="hidden"></div>
       <div id="menu-list-jours"></div>

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -153,6 +153,9 @@ function createMenuList(skipDuplicateCheck = false) {
   if (document.getElementById('chef-menu-button').classList.contains("hidden")) {
     document.getElementById('chef-menu-button').classList.remove("hidden");
   }
+  if (document.getElementById('clear-menu-recipes-button').classList.contains("hidden")) {
+    document.getElementById('clear-menu-recipes-button').classList.remove("hidden");
+  }
 
   document.getElementById('menu-list-jours').classList.remove("hidden");//affiche la liste des menus en cours de création
   const menuContainer = document.querySelector('.list-menu-lists');
@@ -548,10 +551,12 @@ function updateListMenuList (){
   const menuList = document.querySelector('.list-menu-lists');// Trouver le conteneur de la liste des recettes avec la classe 'recipe-list'  dans la section active
 
   menuList.innerHTML = listMenuList.map((menuList, index) => `
-    <div class="recipe-card" onclick="showMenuListDetails(${index})">
-      <h3>${menuList.name}</h3>
-      <p>Créé le: ${menuList.date}</p>
-      <p>Nombre de recette: ${menuList.recipes.length}</p>
+    <div class="menu-list-card" onclick="showMenuListDetails(${index})">
+      <div class="menu-list-header">
+        <h3>${menuList.name}</h3>
+        <span class="menu-list-date">${menuList.date}</span>
+      </div>
+      <div class="menu-list-recipes">${menuList.recipes.length} recettes</div>
     </div>
   `).join('');
 
@@ -569,6 +574,9 @@ function updateListMenuList (){
   }
   if(!document.getElementById('chef-menu-button').classList.contains("hidden")){
     document.getElementById('chef-menu-button').classList.add("hidden");
+  }
+  if(!document.getElementById('clear-menu-recipes-button').classList.contains("hidden")){
+    document.getElementById('clear-menu-recipes-button').classList.add("hidden");
   }
   const formContainer = document.getElementById('menu-form-container');
   if(formContainer && !formContainer.classList.contains('hidden')){
@@ -728,6 +736,7 @@ function editMenuList (index){
   document.getElementById('menu-list-jours').classList.remove('hidden');
   document.getElementById('save-menu-list-button').classList.remove('hidden');
   document.getElementById('chef-menu-button').classList.remove('hidden');
+  document.getElementById('clear-menu-recipes-button').classList.remove('hidden');
   if(!document.getElementById('creerListMenu').classList.contains('hidden')){
     document.getElementById('creerListMenu').classList.add('hidden');
   }
@@ -782,6 +791,14 @@ function removeFromMenu(dayIndex, slotIndex, event) {
   menuListArray[dayIndex][slotIndex] = null;
 
   // Mettre à jour l'interface pour refléter le changement
+  updateMenuList();
+  updateCurrentShoppingList();
+  refreshCurrentMenuDetails();
+}
+
+function clearMenuRecipes() {
+  menuList.recipes = [];
+  menuListArray = menuListArray.map(day => day.map(() => null));
   updateMenuList();
   updateCurrentShoppingList();
   refreshCurrentMenuDetails();
@@ -868,6 +885,7 @@ export {
   editMenuList,
   deleteMenuList,
   removeFromMenu,
+  clearMenuRecipes,
   drag,
   allowDrop,
   drop,
@@ -886,6 +904,7 @@ if (typeof window !== 'undefined') {
   window.deleteMenuList = deleteMenuList;
   window.addRecipeToMenu = addRecipeToMenu;
   window.removeFromMenu = removeFromMenu;
+  window.clearMenuRecipes = clearMenuRecipes;
   window.drag = drag;
   window.allowDrop = allowDrop;
   window.drop = drop;

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -168,7 +168,7 @@ export const difficulties = [1, 2, 3];
     const form = `
       <form id="recipe-form">
         <h2>${isNewRecipe ? 'Ajouter une recette' : 'Modifier la recette'}</h2>
-        <input type="text" id="recipe-name" value="${recipe.name}" required>
+        <input type="text" id="recipe-name" placeholder="Nom de la recette" value="${recipe.name}" required>
         <input id="recipe-image" type="text" placeholder="URL de l'image" value="${recipe.image || ''}">
         <div class="extra-fields">
           <label>Type de recette :</label>
@@ -184,16 +184,18 @@ export const difficulties = [1, 2, 3];
           ${isNewRecipe ? '' : showIngredientsInEditRecipe(index)}
         </div>
         <button type="button" onclick="addIngredientInputToEdit()">Ajouter un ingrédient</button>
-        <select id="recipe-season" required>
-          ${seasons.map(season => `
-            <option value="${season}" ${season === recipe.season ? 'selected' : ''}>${season}</option>
-          `).join('')}
-        </select>
-        <select id="recipe-rating" required>
-          ${[1, 2, 3, 4, 5].map(rating => `
-            <option value="${rating}" ${rating == recipe.rating ? 'selected' : ''}>${rating} étoile${rating > 1 ? 's' : ''}</option>
-          `).join('')}
-        </select>
+        <div class="extra-fields">
+          <select id="recipe-season" required>
+            ${seasons.map(season => `
+              <option value="${season}" ${season === recipe.season ? 'selected' : ''}>${season}</option>
+            `).join('')}
+          </select>
+          <select id="recipe-rating" required>
+            ${[1, 2, 3, 4, 5].map(rating => `
+              <option value="${rating}" ${rating == recipe.rating ? 'selected' : ''}>${rating} étoile${rating > 1 ? 's' : ''}</option>
+            `).join('')}
+          </select>
+        </div>
         <textarea id="recipe-instructions">${recipe.instructions || ''}</textarea>
         <button type="submit">Sauvegarder</button>
       </form>

--- a/styles.css
+++ b/styles.css
@@ -566,3 +566,44 @@ body {
   height: 200px;
 }
 
+/* Compact card style for saved menu lists */
+.menu-list-card {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 10px;
+  cursor: pointer;
+  transition: transform 0.3s;
+}
+
+.menu-list-card:hover {
+  transform: translateY(-5px);
+}
+
+.menu-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.menu-list-date {
+  font-size: 0.8em;
+  color: #666;
+}
+
+.menu-list-recipes {
+  margin-top: 8px;
+  font-weight: bold;
+}
+
+/* Align fields side by side in recipe form */
+.extra-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+.extra-fields > * {
+  flex: 1;
+}
+


### PR DESCRIPTION
## Summary
- rework listing of saved menus with compact menu-list card style
- add button to clear all recipes when editing a menu list
- make recipe creation form more compact with grouped fields and placeholder
- update CSS for new components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485aa0dcf4832c9a1d68cbb654f7f3